### PR TITLE
gpu additions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,3 @@
-Harmony-GPU
------------
-
-This is a GPU implementation of Harmony python package, leading to great speedups for big datasets. This package runs only on CUDA GPUs and requires Rapids libraries with cupy>=9.
-
-To install:
-
-	$> pip install git+https://github.com/LouisFaure/Harmony-GPU
-	
-The following modifications have been made:
-* `sklearn.neighbors.NearestNeighbors` has been replaced by `cuml.NearestNeighbors`
-* `sklearn.linear_model.LinearRegression` has been replaced by `cuml.LinearRegression`
-* `scipy.sparse.find` has been replaced by `cupyx.scipy.sparse.find` in some instances
-*  'rapids' has beeen added to the 'method' parameter in the call of `sc.pp.neighbors`
-* `fa2.ForceAtlas2` has been replaced by `cugraph.ForceAtlas2`
-* `_mnn_ka_distances` function has been replaced by a faster one
-
-
 Harmony
 ------
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
+Harmony-GPU
+-----------
+
+This is a GPU implementation of Harmony python package, leading to great speedups for big datasets. This package runs only on CUDA GPUs and requires Rapids libraries with cupy>=9.
+
+To install:
+
+	$> pip install git+https://github.com/LouisFaure/Harmony-GPU
+	
+The following modifications have been made:
+* `sklearn.neighbors.NearestNeighbors` has been replaced by `cuml.NearestNeighbors`
+* `sklearn.linear_model.LinearRegression` has been replaced by `cuml.LinearRegression`
+* `scipy.sparse.find` has been replaced by `cupyx.scipy.sparse.find` in some instances
+*  'rapids' has beeen added to the 'method' parameter in the call of `sc.pp.neighbors`
+* `fa2.ForceAtlas2` has been replaced by `cugraph.ForceAtlas2`
+* `_mnn_ka_distances` function has been replaced by a faster one
+
+
 Harmony
 ------
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ All the dependencies will be automatically installed using the above commands
 	
 		$> pip install rpy2
 		
+5. If you would like to speed-up the analysis in case of big datasets, you can run the main functions of this package on a CUDA GPU. To do so please install `rapids-0.17` as well as `cupy>=9.0`.
+		
 
 #### Usage
 

--- a/src/harmony/core.py
+++ b/src/harmony/core.py
@@ -67,7 +67,8 @@ def augmented_affinity_matrix(
 
 
     temp = sc.AnnData(data_df.values)
-    sc.pp.neighbors(temp, n_pcs=0, n_neighbors=n_neighbors,method='rapids')
+    # the following call is the now the bottleneck:
+    sc.pp.neighbors(temp, n_pcs=0, n_neighbors=n_neighbors,method='rapids') 
     # maintaining backwards compatibility to Scanpy `sc.pp.neighbors`
     try:
         kNN = temp.uns['neighbors']['distances']
@@ -164,7 +165,7 @@ def _construct_mnn(t1_cells, t2_cells, data_df, n_neighbors):
     mnn = mnn.sqrt()
     return csr_matrix(mnn)
 
-
+# Rewritten for speed improvements
 def _mnn_ka_distances(mnn, n_neighbors):
     # Function to find distance ka^th neighbor in the mutual nearest neighbor matrix
     ka = np.int(n_neighbors / 3)

--- a/src/harmony/plot.py
+++ b/src/harmony/plot.py
@@ -34,11 +34,12 @@ with warnings.catch_warnings():
 
 warnings.filterwarnings(action="ignore", message="remove_na is deprecated")
 
-import cugraph
-import cudf
-import numpy as np
+from fa2 import ForceAtlas2
 import pandas as pd
-def force_directed_layout(affinity_matrix, cell_names=None, verbose=True, iterations=500):
+import numpy as np
+import random
+
+def force_directed_layout(affinity_matrix, cell_names=None, verbose=True, iterations=500, device='cpu'):
     """" Function to compute force directed layout from the affinity_matrix
     :param affinity_matrix: Sparse matrix representing affinities between cells
     :param cell_names: pandas Series object with cell names
@@ -48,35 +49,60 @@ def force_directed_layout(affinity_matrix, cell_names=None, verbose=True, iterat
     """
 
     init_coords = np.random.random((affinity_matrix.shape[0], 2))
- 
     
-    offsets = cudf.Series(affinity_matrix.indptr)
-    indices = cudf.Series(affinity_matrix.indices)
-    G = cugraph.Graph()
-    G.from_cudf_adjlist(offsets, indices, None)
+    if device == 'cpu':
+        forceatlas2 = ForceAtlas2(
+            # Behavior alternatives
+            outboundAttractionDistribution=False,  
+            linLogMode=False,  
+            adjustSizes=False,  
+            edgeWeightInfluence=1.0,
+            # Performance
+            jitterTolerance=1.0,  
+            barnesHutOptimize=True,
+            barnesHutTheta=1.2,
+            multiThreaded=False,  
+            # Tuning
+            scalingRatio=2.0,
+            strongGravityMode=False,
+            gravity=1.0,
+            # Log
+            verbose=verbose)
 
-    forceatlas2 = cugraph.layout.force_atlas2(
-        G,
-        max_iter=iterations,
-        pos_list=cudf.DataFrame(
-            {
-                "vertex": np.arange(init_coords.shape[0]),
-                "x": init_coords[:, 0],
-                "y": init_coords[:, 1],
-            }
-        ),
-        outbound_attraction_distribution=False,
-        lin_log_mode=False,
-        edge_weight_influence=1.0,
-        jitter_tolerance=1.0,
-        barnes_hut_optimize=True,
-        barnes_hut_theta=1.2,
-        scaling_ratio=2.0,
-        strong_gravity_mode=False,
-        gravity=1.0,
-        verbose=True,
-    )
-    positions = forceatlas2.to_pandas().loc[:, ["x", "y"]].values
+        positions = forceatlas2.forceatlas2(
+            affinity_matrix, pos=init_coords, iterations=iterations)
+        positions = np.array(positions)
+        
+    elif device == 'gpu':
+        import cugraph
+        import cudf
+        offsets = cudf.Series(affinity_matrix.indptr)
+        indices = cudf.Series(affinity_matrix.indices)
+        G = cugraph.Graph()
+        G.from_cudf_adjlist(offsets, indices, None)
+
+        forceatlas2 = cugraph.layout.force_atlas2(
+            G,
+            max_iter=iterations,
+            pos_list=cudf.DataFrame(
+                {
+                    "vertex": np.arange(init_coords.shape[0]),
+                    "x": init_coords[:, 0],
+                    "y": init_coords[:, 1],
+                }
+            ),
+            outbound_attraction_distribution=False,
+            lin_log_mode=False,
+            edge_weight_influence=1.0,
+            jitter_tolerance=1.0,
+            barnes_hut_optimize=True,
+            barnes_hut_theta=1.2,
+            scaling_ratio=2.0,
+            strong_gravity_mode=False,
+            gravity=1.0,
+            verbose=True,
+        )
+        positions = forceatlas2.to_pandas().loc[:, ["x", "y"]].values
 
     # Convert to dataframe
     if cell_names is None:


### PR DESCRIPTION
As discussed on issue #17, here is a pull request with gpu accelerated code added! A simple `device="gpu"` is needed when calling `harmony.core.augmented_affinity_matrix` and `harmony.plot.force_directed_layout`.

The code has been tested and needs rapids-0.17 as well as cupy>=9.0 (I haven't added these packages to the requirements, I instead mention these in the README), right now cupy 9.0 is in beta, but a stable version should be out in the coming months.

Here is what is happening when running on GPU:
* `cuml.NearestNeighbors` is used instead of `sklearn.neighbors.NearestNeighbors` and `sc.pp.neighbors`
* `cuml.LinearRegression` is used instead of `sklearn.linear_model.LinearRegression` 
* `cugraph.ForceAtlas2` is used instead of `fa2.ForceAtlas2` 
* `cuml.PCA` is used instead of `sklearn.decomposition.PCA`

As a side note, `_mnn_ka_distances` function has been slightly modified for speedups.

Here is a comparison using the included example data:

![Screenshot 2021-02-28 162055](https://user-images.githubusercontent.com/27488782/109423735-f4b3ee80-79e0-11eb-8f5a-de2aec1c8d4f.png)
