### PR TITLE
Update core.py for numpy > 1.20.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "pandas>=0.22.0",
         "scipy>=1.0.1",
         "scikit-learn",
-        "fa2",
+        "fa2_modified",
         "matplotlib>=2.2.2",
         "seaborn>=0.8.1",
         "palantir>=0.2.3",

--- a/src/harmony/core.py
+++ b/src/harmony/core.py
@@ -56,7 +56,7 @@ def augmented_affinity_matrix(
     # dists, _ = nbrs.kneighbors(pca_projections.values)
     # adj = nbrs.kneighbors_graph(pca_projections.values, mode='distance')
     # # Scaling factors for affinity matrix construction
-    # ka = np.int(n_neighbors / 3)
+    # ka = int(n_neighbors / 3)
     # scaling_factors = pd.Series(dists[:, ka], index=cell_order)
     # # Affinity matrix
     # nn_aff = _convert_to_affinity(adj, scaling_factors, True)
@@ -189,7 +189,7 @@ def _construct_mnn(t1_cells, t2_cells, data_df, n_neighbors,device,n_jobs=-2):
 # Rewritten for speed improvements
 def _mnn_ka_distances(mnn, n_neighbors):
     # Function to find distance ka^th neighbor in the mutual nearest neighbor matrix
-    ka = np.int(n_neighbors / 3)
+    ka = int(n_neighbors / 3)
     ka_dists = np.repeat(None, mnn.shape[0])
     x, y, z = find(mnn)
     rows=pd.Series(x).value_counts()

--- a/src/harmony/plot.py
+++ b/src/harmony/plot.py
@@ -34,7 +34,7 @@ with warnings.catch_warnings():
 
 warnings.filterwarnings(action="ignore", message="remove_na is deprecated")
 
-from fa2 import ForceAtlas2
+from fa2_modified import ForceAtlas2
 import pandas as pd
 import numpy as np
 import random


### PR DESCRIPTION
I did a simple find and replace of np.int with built-in python int

This is described at https://numpy.org/devdocs/release/1.20.0-notes.html

Note this: When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. I did not do this.

With this, harmonyTS runs on my recent python 3.11 with latest scanpy and numpy==2.1.3